### PR TITLE
Add support for a PCP Archive realm.

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-introspection",
-    "version": "9.0.0",
+    "version": "10.0.0",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/configuration/datawarehouse.d/introspection.json
+++ b/configuration/datawarehouse.d/introspection.json
@@ -199,5 +199,157 @@
                 "unit": "Seconds"
             }
         }
+    },
+    "PCPArchives": {
+        "aggregate_schema": "modw_aggregates",
+        "aggregate_table_alias": "agg",
+        "aggregate_table_prefix": "pcparchives_by_",
+        "datasource": "Job Performance Summarizer",
+        "group_bys": {
+            "day": {
+                "$ref": "datawarehouse.d/ref/group-by-time-period.json#/day"
+            },
+            "month": {
+                "$ref": "datawarehouse.d/ref/group-by-time-period.json#/month"
+            },
+            "quarter": {
+                "$ref": "datawarehouse.d/ref/group-by-time-period.json#/quarter"
+            },
+            "year": {
+                "$ref": "datawarehouse.d/ref/group-by-time-period.json#/year"
+            },
+            "none": {
+                "$ref": "datawarehouse.d/ref/group-by-none.json"
+            },
+            "resource": {
+                "attribute_table_schema": "modw",
+                "attribute_to_aggregate_table_key_map": [
+                    {
+                        "id": "resource_id"
+                    }
+                ],
+                "attribute_values_query": {
+                    "joins": [
+                        {
+                            "name": "resourcefact"
+                        },
+                        {
+                            "name": "resourcespecs",
+                            "on": "resourcefact.id = resourcespecs.resource_id"
+                        }
+                    ],
+                    "orderby": [
+                        "resourcefact.code",
+                        "resourcefact.name"
+                    ],
+                    "query_hint": "DISTINCT",
+                    "records": {
+                        "id": "resourcefact.id",
+                        "name": "REPLACE(resourcefact.code, '-', ' ')",
+                        "order_id": "id",
+                        "short_name": "REPLACE(resourcefact.code, '-', ' ')"
+                    },
+                    "where": [
+                        "resourcespecs.processors IS NOT NULL"
+                    ]
+                },
+                "category": "Administrative",
+                "description_html": "A resource is a remote computer that can run jobs.",
+                "name": "Resource"
+            },
+            "jobwalltime": {
+                "attribute_table_schema": "modw",
+                "attribute_to_aggregate_table_key_map": [
+                    {
+                        "id": "archivelength_bucket_id"
+                    }
+                ],
+                "attribute_values_query": {
+                    "joins": [
+                        {
+                            "name": "job_times"
+                        }
+                    ],
+                    "orderby": [
+                        "id"
+                    ],
+                    "records": {
+                        "id": "id",
+                        "name": "description",
+                        "order_id": "id",
+                        "short_name": "description"
+                    }
+                },
+                "category": "Usage",
+                "chart_options": {
+                    "dataset_display_type": {
+                        "aggregate": "bar",
+                        "timeseries": "area"
+                    }
+                },
+                "data_sort_order": null,
+                "description_html": "Archives binned by the amount of time they span",
+                "name": "Archive Wall Time"
+            }
+        },
+        "module": "introspection",
+        "name": "PCPArchives",
+        "order": 200,
+        "statistics": {
+            "avg_wallduration_hours": {
+                "$ref": "datawarehouse.d/ref/Jobs-statistics.json#/avg_wallduration_hours"
+            },
+            "avg_wallduration_seconds": {
+                "aggregate_formula": "COALESCE(SUM(agg.wallduration)/SUM(CASE ${DATE_TABLE_ID_FIELD} WHEN ${MIN_DATE_ID} THEN agg.running_archive_count ELSE agg.started_archive_count END),0)",
+                "timeseries_formula": "COALESCE(SUM(agg.wallduration)/SUM(agg.running_archive_count),0)",
+                "description_html": "The average time, in seconds, a job takes to execute.<br/>In timeseries view mode, the statistic shows the average wall time per job per time period. In aggregate view mode the statistic only includes the job wall hours between the defined time range. The wall hours outside the time range are not included in the calculation.<br /> <i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.",
+                "name": "Wall Time: Per Job",
+                "precision": 0,
+                "unit": "Seconds"
+            },
+            "running_archive_count": {
+                "description_html": "The total number of archives that contained data within the selected duration.",
+                "formula": "COALESCE(SUM(agg.running_archive_count), 0)",
+                "name": "Number of Archives Running",
+                "precision": 0,
+                "unit": "Number of Archives"
+            },
+            "started_archive_count": {
+                "description_html": "The total number of archives that started within the selected duration.",
+                "formula": "COALESCE(SUM(agg.started_archive_count), 0)",
+                "name": "Number of Archives Started",
+                "precision": 0,
+                "unit": "Number of Archives"
+            },
+            "ended_archive_count": {
+                "description_html": "The total number of archives that ended within the selected duration.",
+                "formula": "COALESCE(SUM(agg.ended_archive_count), 0)",
+                "name": "Number of Archives Ended",
+                "precision": 0,
+                "unit": "Number of Archives"
+            },
+            "sem_avg_wallduration_hours": {
+                "$ref": "datawarehouse.d/ref/Jobs-statistics.json#/sem_avg_wallduration_hours"
+            },
+            "sem_avg_wallduration_seconds": {
+                "aggregate_formula": "SQRT(COALESCE(((SUM(agg.sum_wallduration_squared) / SUM(agg.ended_archive_count)) - POW( SUM(agg.wallduration) / SUM(agg.ended_archive_count) , 2)) / SUM(agg.ended_archive_count), 0))",
+                "timeseries_formula": "SQRT(COALESCE(((SUM(agg.sum_wallduration_squared) / SUM(agg.running_archive_count)) - POW( SUM(agg.wallduration) / SUM(agg.running_archive_count) , 2)) / SUM(agg.running_archive_count) , 0))",
+                "description_html": "Standard error calculation",
+                "name": "Std Dev: Wall Time: Per Job",
+                "precision": 2,
+                "show_in_catalog": false,
+                "unit": "Seconds"
+            },
+            "total_wallduration_hours": {
+                "$ref": "datawarehouse.d/ref/Jobs-statistics.json#/total_wallduration_hours"
+            },
+            "total_wallduration_seconds": {
+                "description_html": "The total time, in seconds, ${ORGANIZATION_NAME} jobs took to execute.<br/><i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.",
+                "formula": "COALESCE(SUM(agg.wallduration),0)",
+                "name": "Wall Time: Total",
+                "precision": 0,
+                "unit": "Seconds"
+            }
+        }
     }
 }

--- a/configuration/etl/etl.d/introspection.json
+++ b/configuration/etl/etl.d/introspection.json
@@ -85,5 +85,33 @@
             "table_prefix": "logtimes_by_",
             "aggregation_units": ["day", "month", "quarter", "year"]
         }
+    ],
+    "pcpaggregation": [
+        {
+            "name": "pcpaggregation",
+            "namespace": "ETL\\Aggregator",
+            "options_class": "AggregatorOptions",
+            "class": "SimpleAggregator",
+            "truncate_destination": false,
+            "description": "Aggregate PCP archive data",
+            "definition_file": "introspection/pcparchives_by.json",
+            "table_prefix": "pcparchives_by_",
+            "aggregation_units": ["day", "month", "quarter", "year"],
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "xdmod archive DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_supremm"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "pcparchive",
+                    "config": "datawarehouse",
+                    "schema": "modw_aggregates",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        }
     ]
 }

--- a/configuration/etl/etl_action_defs.d/introspection/pcparchives_by.json
+++ b/configuration/etl/etl_action_defs.d/introspection/pcparchives_by.json
@@ -1,0 +1,67 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/introspection/pcparchives_by.json#/table_definition"
+    },
+    "aggregation_period_query": {
+        "overseer_restrictions": {
+            "start_date": "FROM_UNIXTIME(end_time_ts) >= ${VALUE}",
+            "end_date": "FROM_UNIXTIME(end_time_ts) <= ${VALUE}"
+	},
+        "conversions": {
+            "start_day_id": "YEAR(FROM_UNIXTIME(start_time_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(start_time_ts))",
+            "end_day_id": "YEAR(FROM_UNIXTIME(end_time_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(end_time_ts))"
+        }
+    },
+    "source_query": {
+        "query_hint": "SQL_NO_CACHE",
+        "records": {
+            "${AGGREGATION_UNIT}_id": "${:PERIOD_ID}",
+            "year": "${:YEAR_VALUE}",
+            "${AGGREGATION_UNIT}": "${:PERIOD_VALUE}",
+            "resource_id": "h.resource_id",
+            "node_id": "a.host_id",
+            "archivelength_bucket_id": "(SELECT id FROM ${UTILITY_SCHEMA}.job_times jt WHERE (a.end_time_ts - a.start_time_ts) >= jt.min_duration AND (a.end_time_ts - a.start_time_ts) <= jt.max_duration)",
+            "started_archive_count": "sum(case when a.start_time_ts between ${:PERIOD_START_TS} and ${:PERIOD_END_TS} then 1 else 0 end)",
+            "running_archive_count": "sum(1)",
+            "ended_archive_count": "sum(case when a.end_time_ts between ${:PERIOD_START_TS} and ${:PERIOD_END_TS} then 1 else 0 end)",
+            "wallduration": "COALESCE(SUM( ${wallduration_case_statement}), 0)",
+            "sum_wallduration_squared": "COALESCE(SUM( CAST(POW(${wallduration_case_statement}, 2) AS DECIMAL(36,4)) ), 0)"
+        },
+        "groupby": [
+            "node_id",
+            "resource_id",
+            "archivelength_bucket_id"
+        ],
+        "joins": [
+            {
+                "name": "archives_nodelevel",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "a"
+            },
+            {
+                "name": "hosts",
+                "schema": "${UTILITY_SCHEMA}",
+                "alias": "h",
+                "on": "a.host_id = h.id",
+                "type": "STRAIGHT"
+            }
+        ],
+        "where": [
+            "YEAR(FROM_UNIXTIME(a.start_time_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(a.start_time_ts)) <= ${:PERIOD_END_DAY_ID} AND YEAR(FROM_UNIXTIME(a.end_time_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(a.end_time_ts)) >= ${:PERIOD_START_DAY_ID}"
+        ],
+        "macros": [
+            {
+                "name": "wallduration_case_statement",
+                "file": "statistic_ratio_case.sql",
+                "args": {
+                    "statistic": "(a.end_time_ts - a.start_time_ts)",
+                    "max": "${:PERIOD_SECONDS}",
+                    "src_start_ts": "a.start_time_ts",
+                    "src_end_ts": "a.end_time_ts",
+                    "dest_start_ts": "${:PERIOD_START_TS}",
+                    "dest_end_ts": "${:PERIOD_END_TS}"
+                }
+            }
+        ]
+    }
+}

--- a/configuration/etl/etl_tables.d/introspection/pcparchives_by.json
+++ b/configuration/etl/etl_tables.d/introspection/pcparchives_by.json
@@ -1,0 +1,108 @@
+{
+    "table_definition": {
+        "name": "pcparchives_by",
+        "table_prefix": "pcparchives_by_",
+        "engine": "InnoDB",
+        "comment": "PCP archives aggregate table",
+        "columns": [
+            {
+                "name": "${AGGREGATION_UNIT}_id",
+                "type": "int(10) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The id related to modw.${AGGREGATION_UNIT}s."
+            },
+            {
+                "name": "year",
+                "type": "smallint(5) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The year of the ${AGGREGATION_UNIT}"
+            },
+            {
+                "name": "${AGGREGATION_UNIT}",
+                "type": "smallint(5) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The ${AGGREGATION_UNIT} of the year."
+            },
+            {
+                "name": "node_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The compute node that ran pcp"
+            },
+            {
+                "name": "resource_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: the compute resource"
+            },
+            {
+                "name": "archivelength_bucket_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: Archive length is bucketed based on prechosen intervals in the modw.job_times table."
+            },
+            {
+                "name": "started_archive_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of archives that were created during this period."
+            },
+            {
+                "name": "running_archive_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of archives that contain data during this period."
+            },
+            {
+                "name": "ended_archive_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of archives that were ended during this period."
+            },
+            {
+                "name": "wallduration",
+                "type": "decimal(18,0)",
+                "comment": "FACT: (seconds) The wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days.",
+                "nullable": true
+            },
+            {
+                "name": "sum_wallduration_squared",
+                "type": "double",
+                "comment": "FACT: (seconds) The sum of the square of wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days.",
+                "nullable": true
+            }
+        ],
+        "indexes": [
+            {
+                "name": "index_pcparchives_by_${AGGREGATION_UNIT}_${AGGREGATION_UNIT}_id",
+                "columns": [
+                    "${AGGREGATION_UNIT}_id"
+                ]
+            },
+            {
+                "name": "index_pcparchives_by_${AGGREGATION_UNIT}_${AGGREGATION_UNIT}",
+                "columns": [
+                    "${AGGREGATION_UNIT}"
+                ]
+            },
+            {
+                "name": "index_pcparchives_node_id",
+                "columns": [
+                    "node_id"
+                ]
+            },
+            {
+                "name": "index_pcparchives_resource_id",
+                "columns": [
+                    "resource_id"
+                ]
+            },
+            {
+                "name": "index_pcparchives_length_bucket_id",
+                "columns": [
+                    "archivelength_bucket_id"
+                ]
+            }
+        ]
+    }
+}

--- a/configuration/resource_types.d/introspection.json
+++ b/configuration/resource_types.d/introspection.json
@@ -1,8 +1,13 @@
 {
     "+resource_types": {
-        "+HPC": {
+        "+HTC": {
             "+realms": [
                 "Introspection"
+            ]
+        },
+        "+Gateway": {
+            "+realms": [
+                "PCPArchives"
             ]
         }
     }

--- a/configuration/roles.d/introspection.json
+++ b/configuration/roles.d/introspection.json
@@ -1,7 +1,7 @@
 {
     "module": "introspection",
     "+roles": {
-        "+po": {
+        "+cd": {
             "+query_descripters": [
                 {
                     "realm": "Introspection",
@@ -26,6 +26,18 @@
                 {
                     "realm": "Introspection",
                     "group_by": "logsource"
+                },
+                {
+                    "realm": "PCPArchives",
+                    "group_by": "none"
+                },
+                {
+                    "realm": "PCPArchives",
+                    "group_by": "jobwalltime"
+                },
+                {
+                    "realm": "PCPArchives",
+                    "group_by": "resource"
                 }
             ]
         }


### PR DESCRIPTION
This adds a basic pcp archive realm that displays information from the modw_supremm.archive tables that contain metadata about the various pcp archives.

I want this to run on metrics-dev so made a couple of (backwards compatible ish) changes:
- change role restrictions to be center director rather than program officer (there is no program officer role on open xdmod and it doesn't really matter what the role is set to on xsede xdmod since its only on dev.
- change the resource_types so that the PCPArchive realm only shows on open xdmod and the Introspection realm only shows on xsede xdmod. This exploits the fact that the resource_types enabled on these two instances are different.