### PR TITLE
Update function prototype.

### DIFF
--- a/classes/ETL/Ingestor/XDMoDLogIngestor.php
+++ b/classes/ETL/Ingestor/XDMoDLogIngestor.php
@@ -17,7 +17,7 @@ class XDMoDLogIngestor extends pdoIngestor implements iAction
     /**
      * @see ETL\Ingestor\pdoIngestor::transform()
      */
-    protected function transform(array $srcRecord, $orderId)
+    protected function transform(array $srcRecord, &$orderId)
     {
         $transformedRecord = array();
 


### PR DESCRIPTION
php 7 warns agains the mismatch between the function prototype and the parent class function defn.
```
PHP Warning:  Declaration of ETL\Ingestor\XDMoDLogIngestor::transform(array $srcRecord, $orderId) should be compatible with ETL\Ingestor\pdoIngestor::transform(array $srcRecord, &$orderId) in /data/www/xdmod/share/classes/ETL/Ingestor/XDMoDLogIngestor.php on line 15
```

Tested on XDMoD dev by changing the code then running the etl pipeline and observing it worked without
producing any warnings.

```
php /data/www/xdmod/share/tools/etl/etl_overseer.php -s 'now - 2 weeks' -p introspection.ingestion -p introspection.aggregation -v warning
```
